### PR TITLE
Make login form compatible with new user model in backend.

### DIFF
--- a/config/project.js
+++ b/config/project.js
@@ -26,6 +26,7 @@ const uriOptions = {
   slugs: {
     graphql: 'gql',
     jwtRetrieve: 'api-token-auth',
+    forum: 'forum'
   },
 };
 
@@ -37,6 +38,9 @@ if (process.env.NODE_ENV === 'development') {
   );
   config.setJwtEndpoint(
     `http://${uriOptions.servers.development}/${uriOptions.slugs.jwtRetrieve}/`
+  );
+  config.setForumEndpoint(
+    `http://${uriOptions.servers.development}/${uriOptions.slugs.forum}/`
   );
   // eslint-disable-next-line no-console
   console.log(`set graphql endpoint to ${config.graphQLEndpoint} in project config`);

--- a/kit/config.js
+++ b/kit/config.js
@@ -22,6 +22,7 @@ class Common {
 
     // Endpoint to retrieve jwt token. This needs setting via config.setJwtEndpoint()`
     this.jwtEndpoint = null;
+    this.forumEndpoint = null;
   }
 
   /* REDUX */
@@ -59,6 +60,10 @@ class Common {
     this.jwtEndpoint = uri;
   }
 
+  // Set a URI to retrieve jwt tokens for auth
+  setForumEndpoint(uri) {
+    this.forumEndpoint = uri;
+  }
   // Register Apollo middleware function
   addApolloMiddleware(middlewareFunc) {
     this.apolloMiddleware.push(middlewareFunc);

--- a/src/components/main/LoginModal.js
+++ b/src/components/main/LoginModal.js
@@ -108,7 +108,7 @@ class LoginModal extends Component {
             >
               <div>
                 <label>Username:</label>
-                <input type="text" name="username" />
+                <input type="text" name="slug" />
               </div>
               <div>
                 <label>Password:</label>

--- a/src/components/modules/Forum.js
+++ b/src/components/modules/Forum.js
@@ -1,9 +1,33 @@
 import React from 'react';
 
-const Forum = () => (
-  <div>
+import config from 'kit/config';
+
+import { css, withStyles } from 'src/styles';
+
+// TODO: implement ModuleContainer
+// import { ModuleContainer } from 'src/components/base';
+
+const forumStyles = ({}) => ({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    width: '100%',
+    height: '70%'
+  },
+
+  iframe: {
+    height: '700px', // TODO: get child to inherit proper height from parent instead
+  },
+});
+
+const Forum = ({ styles }) => (
+  <div {...css(styles.container)}>
     <h2>Forum module</h2>
+    <iframe
+      src={config.forumEndpoint}
+      {...css(styles.iframe)}>
+    </iframe>
   </div>
 );
 
-export default Forum;
+export default withStyles(forumStyles)(Forum);

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -1,0 +1,16 @@
+import ThemedStyleSheet from 'react-with-styles/lib/ThemedStyleSheet';
+import aphroditeInterface from 'react-with-styles-interface-aphrodite';
+import { css, withStyles } from 'react-with-styles';
+
+// TODO: determine if I should only register once at the top level, or if I
+// should actually import everywhere (rerunning with each import?)
+
+// TODO: figure out how this interface works
+ThemedStyleSheet.registerInterface(aphroditeInterface);
+
+ThemedStyleSheet.registerTheme({
+  color: 'green',
+});
+
+// TODO: determine the utility of exporting ThemedStyleSheet
+export { css, withStyles, ThemedStyleSheet };


### PR DESCRIPTION
To begin adding the misago forum to the django backend, the user model in the backend has been changed. This commit updates the login form to work with the new model, as follows:

Misago user model uses 'slug' as its username field  rather than 'username' (at least according to rest-framework-jwt) and so the username field should be submitted as 'slug' rather than 'username' for jwt api to successfully validate login. https://paper.dropbox.com/doc/travailsvictory-log-in-dev-stuff-urw9F3oeUadSzjULXWYiM#:uid=717110692822126848860834&h2=Logging-in-with-user-gets-400-