### PR TITLE
Ensure that requests to server come in with null jwt token.

### DIFF
--- a/config/server.js
+++ b/config/server.js
@@ -42,7 +42,7 @@ if (SERVER) {
   // see config/example.js fmi.
   config.setErrorHandler((e, ctx /* `next` is unused in this example */) => {
     // eslint-disable-next-line no-console
-    ctx.body = `Some kind of error. Check your source code.\n${e.message}\n\n${e}`;
+    ctx.body = `Some kind of error. Check your source code.\n${e.stack}`;
   });
 
   /* CUSTOM KOA APP INSTANTIATION */
@@ -69,5 +69,19 @@ if (SERVER) {
     // Always return `next()`, otherwise the request won't 'pass' to the next
     // middleware in the stack (likely, the React handler)
     return next();
+  });
+
+  /* APOLLO */
+  config.addApolloMiddleware((req, next) => {
+  // TODO: figure out if I should sync server or graphql store with localstorage
+  // for session-like purposes
+    if (!req.options.headers) {
+      req.options.headers = {};
+    }
+
+    // set authorization header for JWT to null; no user for naive response
+    req.options.headers.authorization = `JWT ${null}`;
+
+    next();
   });
 }


### PR DESCRIPTION
This results in an anonymous user being hydrated on the backend,
such that the javascript response renders accordingly. Without
setting the jwt token, views regarding user logic cannot be relied
on rendering properly.

In the future, it may be a goal to sync the token stored locally on
the client/user's side with a store in the server, so that the re-
sponse can be rendered for a given user from the start (i.e. support
full user sessions). But for now, hydrating an anonymous user means
that the first view upon hitting moshi-moji.xyz will be for no user
logged in; then once the browser bundle renders, it should feature
the proper user so long as that user has logged in before.