### PR TITLE
Wrap all server-side React dom renders in renderStatic.

### DIFF
--- a/config/browser.js
+++ b/config/browser.js
@@ -6,7 +6,7 @@ import config from 'kit/config';
 // ----------------------
 // BROWSER CONFIGURATION
 
-// Set browsesr config, by checking `SERVER`
+// Set browser config, by checking `SERVER`
 
 if (!SERVER) {
   /* APOLLO */

--- a/kit/entry/server_dev.js
+++ b/kit/entry/server_dev.js
@@ -21,7 +21,7 @@ import server, { createReactHandler, staticMiddleware } from './server';
 // ----------------------
 
 // Get manifest values
-const css = '/assets/css/style.css';
+const nonAphroditeCss = '/assets/css/style.css';
 const scripts = [
   'vendor.js',
   'browser.js'].map(key => `/${key}`);
@@ -32,7 +32,7 @@ const scripts = [
   const { app, router, listen } = server;
 
   // Create proxy to tunnel requests to the browser `webpack-dev-server`
-  router.get('/*', createReactHandler(css, scripts));
+  router.get('/*', createReactHandler(nonAphroditeCss, scripts));
 
   // Connect the development routes to the server
   app

--- a/kit/entry/server_prod.js
+++ b/kit/entry/server_prod.js
@@ -34,7 +34,7 @@ const [manifest, chunkManifest] = ['manifest', 'chunk-manifest'].map(
 );
 
 // Get manifest values
-const css = manifest['browser.css'];
+const nonAphroditeCss = manifest['browser.css'];
 const scripts = [
   'manifest.js',
   'vendor.js',
@@ -46,7 +46,7 @@ const scripts = [
   const { app, router, listen } = server;
 
   // Connect the production routes to the server
-  router.get('/*', createReactHandler(css, scripts, chunkManifest));
+  router.get('/*', createReactHandler(nonAphroditeCss, scripts, chunkManifest));
   app
     .use(staticMiddleware())
     .use(router.routes())

--- a/kit/lib/apollo.js
+++ b/kit/lib/apollo.js
@@ -19,8 +19,6 @@ import { getServerURL } from 'kit/lib/env';
 // Helper function to create a new Apollo client, by merging in
 // passed options alongside any set by `config.setApolloOptions` and defaults
 export function createClient(opt = {}) {
-  console.log('creating Apollo client; config.apolloClientOptions are',
-  config.apolloClientOptions);
   return new ApolloClient(Object.assign({
     reduxRootSelector: state => state.apollo,
   }, config.apolloClientOptions, opt));

--- a/kit/views/ssr.js
+++ b/kit/views/ssr.js
@@ -5,39 +5,76 @@
 // ----------------------
 // IMPORTS
 import React from 'react';
+import ReactDOMServer from 'react-dom/server';
 import PropTypes from 'prop-types';
+
+// Import Aphrodite StyleSheetServer to gather Aphrodite styles as static asset
+// (necessary for SSR, as Aphrodite typically assumes it's being invoked in the
+// browser: https://github.com/khan/aphrodite#server-side-rendering)
+import { StyleSheetServer } from 'aphrodite';
 
 // ----------------------
 
-const Html = ({ head, scripts, window, css, children }) => (
-  <html lang="en" prefix="og: http://ogp.me/ns#">
-    <head>
-      <meta charSet="utf-8" />
-      <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
-      <meta httpEquiv="Content-Language" content="en" />
-      <meta name="viewport" content="width=device-width, initial-scale=1" />
-      {head.meta.toComponent()}
-      <link rel="stylesheet" href={css} />
-      {head.title.toComponent()}
-    </head>
-    <body>
-      <div id="main">{children}</div>
-      <script
-        dangerouslySetInnerHTML={{
-          __html: Object.keys(window).reduce(
-            (out, key) => out += `window.${key}=${JSON.stringify(window[key])};`,
-            ''),
-        }} />
-      {scripts.map(src => <script key={src} src={src} />)}
-    </body>
-  </html>
-);
+/* COMPONENT: Html
+ *  HTML renders as the server-side HTML response for moshimoji.
+ *  Inputs:
+ *  + props
+ *    + head
+ *    + scripts
+ *    + window
+ *    + nonAphroditeCSS
+ *    + children
+ * Implementation note: Html calls renderToString in order to collect the styles
+ * specified with Aphrodite using renderStatic--see:
+ * https://github.com/khan/aphrodite#server-side-rendering
+ * But -- this implementation  means that a React dom render is performed twice
+ * (once here, and once in the upper scope). May want to change implementation
+ * avoid this in future.
+ */
+// TODO: see implemntation note above
+// TODO: add descriptions for props
+const Html = ({ head, scripts, window, nonAphroditeCss, children }) => {
+  const { html, css } = StyleSheetServer.renderStatic(() =>
+    ReactDOMServer.renderToString(children),
+  );
+
+  return (
+    <html lang="en" prefix="og: http://ogp.me/ns#">
+      <head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta httpEquiv="Content-Language" content="en" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        {head.meta.toComponent()}
+        <link rel="stylesheet" href={nonAphroditeCss} />
+        <style data-aphrodite>${css.content}</style>
+        {head.title.toComponent()}
+      </head>
+      <body>
+        <div
+          id="main"
+          dangerouslySetInnerHTML={{ __html: html,
+          }} />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: Object.keys(window).reduce(
+              (out, key) => out += `window.${key}=${JSON.stringify(window[key])};`,
+              ''),
+          }} />
+        <script>
+          StyleSheet.rehydrate(${JSON.stringify(css.renderedClassNames)});
+        </script>
+        {scripts.map(src => <script key={src} src={src} />)}
+      </body>
+    </html>
+  );
+};
 
 Html.propTypes = {
   head: PropTypes.object.isRequired,
   window: PropTypes.object.isRequired,
   scripts: PropTypes.arrayOf(PropTypes.string).isRequired,
-  css: PropTypes.string.isRequired,
+  nonAphroditeCss: PropTypes.string.isRequired,
   children: PropTypes.element.isRequired,
 };
 


### PR DESCRIPTION
This ensures that Aphrodite styles are collected into a static
asset and logic to inject the styles into a DOM does not run.
Since no DOM is available in server side rendering, failure to wrap
DOM renders in renderStatic results in the error "Cannot
automatically buffer without a document".