### PR TITLE
[bug fix] Add error handling to prevent no-chunking from breaking fe.

### DIFF
--- a/kit/entry/server_prod.js
+++ b/kit/entry/server_prod.js
@@ -28,9 +28,20 @@ import server, { createReactHandler, staticMiddleware } from './server';
 
 // Read in manifest files
 const [manifest, chunkManifest] = ['manifest', 'chunk-manifest'].map(
-  name => JSON.parse(
-    readFileSync(path.resolve(PATHS.dist, `${name}.json`), 'utf8'),
-  ),
+  name => {
+    const file = path.resolve(PATHS.dist, `${name}.json`);
+    try {
+      return JSON.parse(readFileSync(file, 'utf8'));
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        console.log(`Error reading ${file} manifest:\n`, err.message);
+        console.log('If this is for chunk-manifest.json, it probably means no chunking was used to split app into several bundles.');
+        console.log('Defaulting to empty {} for manifest.');
+        return {};
+      }
+      throw err;
+    }
+  },
 );
 
 // Get manifest values


### PR DESCRIPTION
See: https://github.com/reactql/kit/issues/146#issuecomment-368299924

If no chunking is used in the reactql app, no chunk-manifest.json is generated at build time.
The kit would attempt to open and read chunk-manifest.json anyway, which causes ENOENT and crash of process.
This change adds error handling to prevent crash of process.
